### PR TITLE
Refactor: issueList 리팩토링

### DIFF
--- a/src/components/listItem/IssueItem.tsx
+++ b/src/components/listItem/IssueItem.tsx
@@ -5,21 +5,18 @@ import { styled } from 'styled-components';
 import { IssueType } from 'types';
 import { changeDateFormat } from 'utils/changeDateFormat';
 
-interface IssueItemPropsType {
-  issue: IssueType;
-}
-function IssueItem({ issue }: IssueItemPropsType) {
+function IssueItem({ number, title, created_at, comments, user }: IssueType) {
   const { pathname } = useLocation();
   return (
     <IssueItemWrapper $pathname={pathname}>
-      <Link to={`/detail/${issue.number}`} state={{ number: issue.number }}>
-        &#35;{`${issue.number} ${issue.title}`}
+      <Link to={`/detail/${number}`} state={{ number: number }}>
+        &#35;{`${number} ${title}`}
       </Link>
       <div>
-        <span>작성자: {`${issue.user.login}`}, </span>
-        <span>작성일: {`${changeDateFormat(issue.created_at)}`}</span>
+        <span>작성자: {`${user.login}`}, </span>
+        <span>작성일: {`${changeDateFormat(created_at)}`}</span>
       </div>
-      <span className='comment'>코멘트: {`${issue.comments}`}</span>
+      <span className='comment'>코멘트: {`${comments}`}</span>
     </IssueItemWrapper>
   );
 }

--- a/src/pages/IssueDetail.tsx
+++ b/src/pages/IssueDetail.tsx
@@ -27,7 +27,7 @@ function IssueDetail() {
             <div>
               <img src={`${issue.user.avatar_url}`} alt={`${issue.user.login} 이미지`} />
             </div>
-            <div>{<IssueItem issue={issue} />}</div>
+            <div>{<IssueItem {...issue} />}</div>
           </DetailTitle>
           <DetailContent>
             <p>{issue.body}</p>

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -25,16 +25,13 @@ function IssueList() {
       {issueList.length !== 0 ? (
         <IssueListWrapper>
           {issueList.map((issue, idx) => {
-            if ((idx + 1) % 4 === 0) {
-              return (
-                <React.Fragment key={`${issue.id + idx}`}>
-                  <IssueItem key={issue.id} issue={issue} />
-                  <Advertisement key={idx + 1} />
-                </React.Fragment>
-              );
-            } else {
-              return <IssueItem key={issue.id} issue={issue} />;
-            }
+            const repeatAdvertisement = (idx + 1) % 4 === 0;
+            return (
+              <React.Fragment key={`${issue.id + idx}`}>
+                <IssueItem key={issue.id} issue={issue} />
+                {repeatAdvertisement && <Advertisement key={idx + 1} />}
+              </React.Fragment>
+            );
           })}
           <div ref={targetRef}></div>
           {loading && <Loading />}

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -27,9 +27,9 @@ function IssueList() {
           {issueList.map((issue, idx) => {
             const repeatAdvertisement = (idx + 1) % 4 === 0;
             return (
-              <React.Fragment key={`${issue.id + idx}`}>
-                <IssueItem key={issue.id} issue={issue} />
-                {repeatAdvertisement && <Advertisement key={idx + 1} />}
+              <React.Fragment key={issue.number}>
+                <IssueItem issue={issue} />
+                {repeatAdvertisement && <Advertisement />}
               </React.Fragment>
             );
           })}

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -20,25 +20,25 @@ function IssueList() {
     return <ErrorPage />;
   }
 
+  if (issueList.length === 0) {
+    return <Loading />;
+  }
+
   return (
     <Layout>
-      {issueList.length !== 0 ? (
-        <IssueListWrapper>
-          {issueList.map((issue, idx) => {
-            const repeatAdvertisement = (idx + 1) % 4 === 0;
-            return (
-              <React.Fragment key={issue.number}>
-                <IssueItem {...issue} />
-                {repeatAdvertisement && <Advertisement />}
-              </React.Fragment>
-            );
-          })}
-          <div ref={targetRef}></div>
-          {loading && <Loading />}
-        </IssueListWrapper>
-      ) : (
-        <Loading />
-      )}
+      <IssueListWrapper>
+        {issueList.map((issue, idx) => {
+          const repeatAdvertisement = (idx + 1) % 4 === 0;
+          return (
+            <React.Fragment key={issue.number}>
+              <IssueItem {...issue} />
+              {repeatAdvertisement && <Advertisement />}
+            </React.Fragment>
+          );
+        })}
+        <div ref={targetRef}></div>
+        {loading && <Loading />}
+      </IssueListWrapper>
     </Layout>
   );
 }

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -26,16 +26,12 @@ function IssueList() {
         <IssueListWrapper>
           {issueList.map((issue, idx) => {
             const repeatAdvertisement = (idx + 1) % 4 === 0;
-            if (repeatAdvertisement) {
-              return (
-                <React.Fragment key={`${issue.id + idx}`}>
-                  <IssueItem key={issue.id} issue={issue} />
-                  <Advertisement key={idx + 1} />
-                </React.Fragment>
-              );
-            } else {
-              return <IssueItem key={issue.id} issue={issue} />;
-            }
+            return (
+              <React.Fragment key={`${issue.id + idx}`}>
+                <IssueItem key={issue.id} issue={issue} />
+                {repeatAdvertisement && <Advertisement key={idx + 1} />}
+              </React.Fragment>
+            );
           })}
           <div ref={targetRef}></div>
           {loading && <Loading />}

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -28,7 +28,7 @@ function IssueList() {
             const repeatAdvertisement = (idx + 1) % 4 === 0;
             return (
               <React.Fragment key={issue.number}>
-                <IssueItem issue={issue} />
+                <IssueItem {...issue} />
                 {repeatAdvertisement && <Advertisement />}
               </React.Fragment>
             );

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -26,12 +26,16 @@ function IssueList() {
         <IssueListWrapper>
           {issueList.map((issue, idx) => {
             const repeatAdvertisement = (idx + 1) % 4 === 0;
-            return (
-              <React.Fragment key={`${issue.id + idx}`}>
-                <IssueItem key={issue.id} issue={issue} />
-                {repeatAdvertisement && <Advertisement key={idx + 1} />}
-              </React.Fragment>
-            );
+            if (repeatAdvertisement) {
+              return (
+                <React.Fragment key={`${issue.id + idx}`}>
+                  <IssueItem key={issue.id} issue={issue} />
+                  <Advertisement key={idx + 1} />
+                </React.Fragment>
+              );
+            } else {
+              return <IssueItem key={issue.id} issue={issue} />;
+            }
           })}
           <div ref={targetRef}></div>
           {loading && <Loading />}


### PR DESCRIPTION
## Best Practice(이슈 목록 화면)
[🤍원티드 2주차 과제](https://lean-mahogany-686.notion.site/Week-2-a28eb717312a434498ea431d2ff8fc17)
[🫧14팀 2주차 회의록](https://distinct-attraction-cde.notion.site/2-38288f6c7c404d3485e1847feae07e18)
- 4를 상수값으로 처리하기(이미지 삽입)
- 28줄 if문 함수로처리해서 선언형으로 만들자.
- 36줄 issue 전개 연산자 사용해서 수정하자.
- idx + 1 부분을 Issue number로 수정
- <Loding/> 삼항연산자 부분, 깔끔하게 정리하자

## 구현 기능 명세
- 광고 이미지 반복 연산식을 상수(repeatAdvertisement)로 처리
- <IssueItem>이 반복 사용되는 if문을 &&연산자로 변경
- Fragment안의 IssuItem, Advertisement에서 반복 사용되는 key 제거
- issue 전개 연산자 사용(IssueDetail, IssueList ), IssueItem 파라미터 수정
- Loading관련 삼항연산자 제거 및 if문으로 Loading 분리

## 확인 요청
1. `IssueList` L23 IssueList.length === 0일때, Loading 표시를 하는게 필요한지/없어도 동일한지